### PR TITLE
ci: add keepalive workflow to keep scheduled pipelines enabled

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,43 @@
+name: keepalive
+
+# GitHub disables scheduled workflows after 60 days of repository inactivity,
+# which silently stops the data ingestion pipelines. This workflow pushes an
+# empty commit when the repo has been quiet for a while, resetting that clock.
+#
+# It runs weekly but only commits when the last commit is older than
+# KEEPALIVE_AFTER_DAYS, so it adds roughly one commit every 50 days rather
+# than one per week.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: write
+
+env:
+  KEEPALIVE_AFTER_DAYS: 50
+
+jobs:
+  keepalive:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out this repo
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+    - name: push an empty commit if the repo has been inactive
+      run: |-
+        last_commit=$(git log -1 --format=%ct)
+        now=$(date +%s)
+        days=$(( (now - last_commit) / 86400 ))
+        echo "Last commit was $days day(s) ago (threshold: ${KEEPALIVE_AFTER_DAYS})."
+        if [ "$days" -lt "${KEEPALIVE_AFTER_DAYS}" ]; then
+          echo "Repo is active, nothing to do."
+          exit 0
+        fi
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git commit --allow-empty -m "chore: keepalive to prevent scheduled workflows being disabled"
+        git push


### PR DESCRIPTION
## Problem

GitHub Actions disables `schedule`-triggered workflows after **60 days of repository inactivity**. That is what silently killed data ingestion: the last commit was `c07dcb3` on 2026-04-02, and all three pipelines stopped firing on **2026-06-14**, leaving the site stuck on 14 Jun data.

The three workflows have been re-enabled and verified working (cars 1027 rows, bikes 24, air 11 — all with 0 quarantined), but without a fix this will recur after the next 60 quiet days.

## Solution

A `keepalive` workflow that pushes an empty commit when the repo has been inactive, resetting the clock.

It runs weekly but only commits when the last commit is older than `KEEPALIVE_AFTER_DAYS` (50), so it adds roughly **one commit every 50 days** rather than one per week. The 10-day margin against the 60-day deadline absorbs GitHub's cron imprecision and schedule throttling.

Needs `permissions: contents: write` since the repo's default workflow permission is `read`.

## Note

This must be merged to `main` to take effect — scheduled workflows only run from the default branch.